### PR TITLE
add weighted pool support in Balancer

### DIFF
--- a/src/bal.test.ts
+++ b/src/bal.test.ts
@@ -1,4 +1,4 @@
-import { makeAmountOutFunction } from "./make";
+import { makeAmountOutFunction, makeSingleSidedWithdrawalFunction } from "./make";
 
 const comparable = (val) => Math.floor(val / 1e8);
 
@@ -24,20 +24,54 @@ describe("Balancer Stable, 8 digits of imprecision", () => {
   });
 
   describe("Balancer wstETH WETH", () => {
-    it("Velo 1", () => {
+    it("Balancer 1", () => {
       expect(comparable(getAmountOut(1000000000000000000))).toBe(
         comparable(1124698774312831587)
       );
     });
-    it("Velo 2", () => {
+    it("Balancer 2", () => {
       expect(comparable(getAmountOut(10000000000000000000))).toBe(
         comparable(11246774022270881393)
       );
     });
-    it("Velo 3", () => {
+    it("Balancer 3", () => {
       expect(comparable(getAmountOut(50000000000000000000))).toBe(
         comparable(56229016387923591565)
       );
+    });
+  });
+});
+
+describe("Balancer Weighted pool", () => {
+  // example https://arbiscan.io/address/0xc9f52540976385a84bf416903e1ca3983c539e34#readContract
+  const weights = [500000000000000000, 500000000000000000];
+  const reserves = [32623483934735535598, 513793797226418089934];
+  const getAmountOut = makeAmountOutFunction("Balancer", reserves, false, {
+    customRates: weights,
+  });  
+  const _bptTotalSupply = 258758795898650464713;
+  const _bptOutIdx = 1;
+  const getSingleOutGivenBpt = makeSingleSidedWithdrawalFunction("Balancer", reserves, false, _bptTotalSupply, {
+    customRates: weights,
+  }, _bptOutIdx);
+
+  describe("Balancer tBTC wETH", () => {
+    it("Balancer weighted 1", () => {
+      let _out = getAmountOut(100000000000000000);
+      expect(_out).toBe(1569950729771657700);
+    });
+    it("Balancer weighted 2", () => {
+      let _out = getAmountOut(1000000000000000000);
+      expect(_out).toBe(15279319263156986000);
+    });
+    it("Balancer weighted 3", () => {
+      let _out = getAmountOut(5000000000000000000);
+      expect(_out).toBe(68275076046313760000);
+    });
+    it("Balancer weighted single-sided withdrawal 1", () => {
+      // example https://arbiscan.io/tx/0x4c74a2d56a0fd561c41806d6fe66ffab87eae5d8a4407f34d993ba7f664c4fcc
+      let _out = getSingleOutGivenBpt(7138911896188764);
+      expect(_out).toBe(28348367030779050);
     });
   });
 });

--- a/src/bal/weighted/weighted-math.ts
+++ b/src/bal/weighted/weighted-math.ts
@@ -1,0 +1,529 @@
+// Ported from Solidity:
+// https://github.com/balancer-labs/balancer-core-v2/blob/70843e6a61ad11208c1cfabf5cfe15be216ca8d3/pkg/pool-weighted/contracts/WeightedMath.sol
+
+import BigNumber, { bn, scale } from "../bn";
+import * as fp from "../fixed-point";
+
+// Swap limits: amounts swapped may not be larger than this percentage of total balance
+const MAX_IN_RATIO = bn("300000000000000000"); // 0.3e18
+const MAX_OUT_RATIO = bn("300000000000000000"); // 0.3e18
+
+// Invariant growth limit: non-proportional joins cannot cause the invariant to increase by more than this ratio
+const MAX_INVARIANT_RATIO = bn("3000000000000000000"); // 3e18
+// Invariant shrink limit: non-proportional exits cannot cause the invariant to decrease by less than this ratio
+const MIN_INVARIANT_RATIO = bn("700000000000000000"); // 0.7e18
+
+export const _calculateInvariant = (
+  normalizedWeights: BigNumber[],
+  balances: BigNumber[]
+): BigNumber => {
+  /*****************************************************************************************
+  // invariant               _____                                                        //
+  // wi = weight index i      | |      wi                                                 //
+  // bi = balance index i     | |  bi ^   = i                                             //
+  // i = invariant                                                                        //
+  *****************************************************************************************/
+
+  let invariant = fp.ONE;
+  for (let i = 0; i < normalizedWeights.length; i++) {
+    invariant = fp.mulDown(
+      invariant,
+      fp.powDown(balances[i], normalizedWeights[i])
+    );
+  }
+
+  if (invariant.lte(fp.ZERO)) {
+    throw new Error("ZERO_INVARIANT");
+  }
+
+  return invariant;
+};
+
+// Computes how many tokens can be taken out of a pool if `amountIn` is sent, given the
+// current balances and weights.
+export const _calcOutGivenIn = (
+  balanceIn: BigNumber,
+  weightIn: BigNumber,
+  balanceOut: BigNumber,
+  weightOut: BigNumber,
+  amountIn: BigNumber,
+  options?: {
+    swapFeePercentage: BigNumber;
+    tokenInDecimals: number;
+  }
+): BigNumber => {
+  /*****************************************************************************************
+  // outGivenIn                                                                           //
+  // ao = amountOut                                                                       //
+  // bo = balanceOut                                                                      //
+  // bi = balanceIn              /      /            bi             \    (wi / wo) \      //
+  // ai = amountIn    ao = bo * |  1 - | --------------------------  | ^            |     //
+  // wi = weightIn               \      \       ( bi + ai )         /              /      //
+  // wo = weightOut                                                                       //
+  *****************************************************************************************/
+
+  // Amount out, so we round down overall
+
+  // The multiplication rounds down, and the subtrahend (power) rounds up (so the base rounds up too)
+  // Because bi / (bi + ai) <= 1, the exponent rounds down
+
+  if (options) {
+    // Fees are subtracted before scaling
+    const scalingFactor = 18 - options.tokenInDecimals;
+    const scaledAmountIn = scale(amountIn, -scalingFactor);
+    const scaledAmountInWithoutFees = fp.sub(
+      scaledAmountIn,
+      fp.mulUp(scaledAmountIn, options.swapFeePercentage)
+    );
+    amountIn = scale(scaledAmountInWithoutFees, scalingFactor);
+  }
+
+  // Cannot exceed maximum in ratio
+  if (amountIn.gt(fp.mulDown(balanceIn, MAX_IN_RATIO))) {
+    throw new Error("MAX_IN_RATIO");
+  }
+
+  const denominator = fp.add(balanceIn, amountIn);
+  const base = fp.divUp(balanceIn, denominator);
+  const exponent = fp.divDown(weightIn, weightOut);
+  const power = fp.powUp(base, exponent);
+
+  return fp.mulDown(balanceOut, fp.complement(power));
+};
+
+// Computes how many tokens must be sent to a pool in order to take `amountOut`, given the
+// current balances and weights.
+export const _calcInGivenOut = (
+  balanceIn: BigNumber,
+  weightIn: BigNumber,
+  balanceOut: BigNumber,
+  weightOut: BigNumber,
+  amountOut: BigNumber,
+  options?: {
+    swapFeePercentage: BigNumber;
+    tokenInDecimals: number;
+  }
+): BigNumber => {
+  /*****************************************************************************************
+  // inGivenOut                                                                           //
+  // ao = amountOut                                                                       //
+  // bo = balanceOut                                                                      //
+  // bi = balanceIn              /  /            bo             \    (wo / wi)      \     //
+  // ai = amountIn    ai = bi * |  | --------------------------  | ^            - 1  |    //
+  // wi = weightIn               \  \       ( bo - ao )         /                   /     //
+  // wo = weightOut                                                                       //
+  *****************************************************************************************/
+
+  // Amount in, so we round up overall
+
+  // The multiplication rounds up, and the power rounds up (so the base rounds up too)
+  // Because bo / (bo - ao) >= 1, the exponent rounds up
+
+  // Cannot exceed maximum out ratio
+  if (amountOut.gt(fp.mulDown(balanceOut, MAX_OUT_RATIO))) {
+    throw new Error("MAX_OUT_RATIO");
+  }
+
+  const base = fp.divUp(balanceOut, fp.sub(balanceOut, amountOut));
+  const exponent = fp.divUp(weightOut, weightIn);
+  const power = fp.powUp(base, exponent);
+
+  const ratio = fp.sub(power, fp.ONE);
+
+  let amountIn = fp.mulUp(balanceIn, ratio);
+
+  if (options) {
+    // Fees are added after scaling
+    const scalingFactor = 18 - options.tokenInDecimals;
+    const scaledAmountIn = scale(amountIn, -scalingFactor);
+    const scaledAmountInWithFees = fp.divUp(
+      scaledAmountIn,
+      fp.sub(fp.ONE, options.swapFeePercentage)
+    );
+    amountIn = scale(scaledAmountInWithFees, scalingFactor);
+  }
+
+  return amountIn;
+};
+
+export const _calcBptOutGivenExactTokensIn = (
+  balances: BigNumber[],
+  normalizedWeights: BigNumber[],
+  amountsIn: BigNumber[],
+  bptTotalSupply: BigNumber,
+  swapFee: BigNumber
+): BigNumber => {
+  // BPT out, so we round down overall
+
+  const balanceRatiosWithFee = new Array<BigNumber>(amountsIn.length);
+
+  let invariantRatioWithFees = fp.ZERO;
+  for (let i = 0; i < balances.length; i++) {
+    balanceRatiosWithFee[i] = fp.divDown(
+      fp.add(balances[i], amountsIn[i]),
+      balances[i]
+    );
+    invariantRatioWithFees = fp.add(
+      invariantRatioWithFees,
+      fp.mulDown(balanceRatiosWithFee[i], normalizedWeights[i])
+    );
+  }
+
+  let invariantRatio = fp.ONE;
+  for (let i = 0; i < balances.length; i++) {
+    let amountInWithoutFee: BigNumber;
+
+    if (balanceRatiosWithFee[i].gt(invariantRatioWithFees)) {
+      const nonTaxableAmount = fp.mulDown(
+        balances[i],
+        fp.sub(invariantRatioWithFees, fp.ONE)
+      );
+      const taxableAmount = fp.sub(amountsIn[i], nonTaxableAmount);
+
+      amountInWithoutFee = fp.add(
+        nonTaxableAmount,
+        fp.mulDown(taxableAmount, fp.sub(fp.ONE, swapFee))
+      );
+    } else {
+      amountInWithoutFee = amountsIn[i];
+    }
+
+    const balanceRatio = fp.divDown(
+      fp.add(balances[i], amountInWithoutFee),
+      balances[i]
+    );
+
+    invariantRatio = fp.mulDown(
+      invariantRatio,
+      fp.powDown(balanceRatio, normalizedWeights[i])
+    );
+  }
+
+  if (invariantRatio.gte(fp.ONE)) {
+    return fp.mulDown(bptTotalSupply, fp.sub(invariantRatio, fp.ONE));
+  } else {
+    return fp.ZERO;
+  }
+};
+
+export const _calcTokenInGivenExactBptOut = (
+  balance: BigNumber,
+  normalizedWeight: BigNumber,
+  bptAmountOut: BigNumber,
+  bptTotalSupply: BigNumber,
+  swapFee: BigNumber
+): BigNumber => {
+  /*****************************************************************************************
+  // tokenInForExactBptOut                                                                //
+  // a = amountIn                                                                         //
+  // b = balance                      /  /     bpt + bptOut     \    (1 / w)      \       //
+  // bptOut = bptAmountOut   a = b * |  | ---------------------- | ^          - 1  |      //
+  // bpt = bptTotalSupply             \  \         bpt          /                 /       //
+  // w = normalizedWeight                                                                 //
+  *****************************************************************************************/
+
+  // Token in, so we round up overall
+
+  // Calculate the factor by which the invariant will increase after minting `bptAmountOut`
+  const invariantRatio = fp.divUp(
+    fp.add(bptTotalSupply, bptAmountOut),
+    bptTotalSupply
+  );
+  if (invariantRatio.gt(MAX_INVARIANT_RATIO)) {
+    throw new Error("MAX_OUT_BPT_FOR_TOKEN_IN");
+  }
+
+  // Calculate by how much the token balance has to increase to cause `invariantRatio`
+  const balanceRatio = fp.powUp(
+    invariantRatio,
+    fp.divUp(fp.ONE, normalizedWeight)
+  );
+  const amountInWithoutFee = fp.mulUp(balance, fp.sub(balanceRatio, fp.ONE));
+
+  // We can now compute how much extra balance is being deposited and used in virtual swaps, and charge swap fees accordingly
+  const taxablePercentage = fp.complement(normalizedWeight);
+  const taxableAmount = fp.mulUp(amountInWithoutFee, taxablePercentage);
+  const nonTaxableAmount = fp.sub(amountInWithoutFee, taxableAmount);
+
+  return fp.add(
+    nonTaxableAmount,
+    fp.divUp(taxableAmount, fp.complement(swapFee))
+  );
+};
+
+export const _calcBptInGivenExactTokensOut = (
+  balances: BigNumber[],
+  normalizedWeights: BigNumber[],
+  amountsOut: BigNumber[],
+  bptTotalSupply: BigNumber,
+  swapFee: BigNumber
+): BigNumber => {
+  // BPT in, so we round up overall
+
+  const balanceRatiosWithoutFee = new Array<BigNumber>(amountsOut.length);
+
+  let invariantRatioWithoutFees = fp.ZERO;
+  for (let i = 0; i < balances.length; i++) {
+    balanceRatiosWithoutFee[i] = fp.divUp(
+      fp.sub(balances[i], amountsOut[i]),
+      balances[i]
+    );
+    invariantRatioWithoutFees = fp.add(
+      invariantRatioWithoutFees,
+      fp.mulUp(balanceRatiosWithoutFee[i], normalizedWeights[i])
+    );
+  }
+
+  let invariantRatio = fp.ONE;
+  for (let i = 0; i < balances.length; i++) {
+    // Swap fees are typically charged on 'tokenIn', but there is no 'tokenIn' here, so we apply it to
+    // 'tokenOut' - this results in slightly larger price impact
+
+    let amountOutWithFee: BigNumber;
+    if (invariantRatioWithoutFees.gt(balanceRatiosWithoutFee[i])) {
+      const nonTaxableAmount = fp.mulDown(
+        balances[i],
+        fp.complement(invariantRatioWithoutFees)
+      );
+      const taxableAmount = fp.sub(amountsOut[i], nonTaxableAmount);
+
+      amountOutWithFee = fp.add(
+        nonTaxableAmount,
+        fp.divUp(taxableAmount, fp.complement(swapFee))
+      );
+    } else {
+      amountOutWithFee = amountsOut[i];
+    }
+
+    const balanceRatio = fp.divDown(
+      fp.sub(balances[i], amountOutWithFee),
+      balances[i]
+    );
+
+    invariantRatio = fp.mulDown(
+      invariantRatio,
+      fp.powDown(balanceRatio, normalizedWeights[i])
+    );
+  }
+
+  return fp.mulUp(bptTotalSupply, fp.complement(invariantRatio));
+};
+
+export const _calcTokenOutGivenExactBptIn = (
+  balance: BigNumber,
+  normalizedWeight: BigNumber,
+  bptAmountIn: BigNumber,
+  bptTotalSupply: BigNumber,
+  swapFee: BigNumber
+): BigNumber => {
+  /*****************************************************************************************
+  // exactBptInForTokenOut                                                                //
+  // a = amountOut                                                                        //
+  // b = balance                     /      /    bpt - bptIn    \    (1 / w)  \           //
+  // bptIn = bptAmountIn    a = b * |  1 - | ------------------- | ^           |          //
+  // bpt = bptTotalSupply            \      \        bpt        /             /           //
+  // w = weight                                                                           //
+  *****************************************************************************************/
+
+  // Token out, so we round down overall
+  // The multiplication rounds down, but the power rounds up (so the base rounds up)
+  // Because (bpt - bptIn) / bpt <= 1, the exponent rounds down
+
+  // Calculate the factor by which the invariant will decrease after burning `bptAmountIn`
+  const invariantRatio = fp.divUp(
+    fp.sub(bptTotalSupply, bptAmountIn),
+    bptTotalSupply
+  );
+  if (invariantRatio.lt(MIN_INVARIANT_RATIO)) {
+    throw new Error("MIN_BPT_IN_FOR_TOKEN_OUT");
+  }
+
+  // Calculate by how much the token balance has to increase to cause `invariantRatio`
+  const balanceRatio = fp.powUp(
+    invariantRatio,
+    fp.divDown(fp.ONE, normalizedWeight)
+  );
+
+  // Because of rounding up, `balanceRatio` can be greater than one, so we use its complement
+  const amountOutWithoutFee = fp.mulDown(balance, fp.complement(balanceRatio));
+
+  // We can now compute how much excess balance is being withdrawn as a result of the virtual swaps,
+  // which result in swap fees
+  const taxablePercentage = fp.complement(normalizedWeight);
+
+  // Swap fees are typically charged on 'tokenIn', but there is no 'tokenIn' here, so we apply it
+  // to 'tokenOut' - this results in slightly larger price impact (fees are rounded up)
+  const taxableAmount = fp.mulUp(amountOutWithoutFee, taxablePercentage);
+  const nonTaxableAmount = fp.sub(amountOutWithoutFee, taxableAmount);
+
+  return fp.add(
+    nonTaxableAmount,
+    fp.mulDown(taxableAmount, fp.complement(swapFee))
+  );
+};
+
+export const _calcTokensOutGivenExactBptIn = (
+  balances: BigNumber[],
+  bptAmountIn: BigNumber,
+  bptTotalSupply: BigNumber
+): BigNumber[] => {
+  /*****************************************************************************************
+  // exactBptInForTokensOut                                                               //
+  // (formula per token)                                                                  //
+  // ao = amountOut                  /   bptIn   \                                        //
+  // b = balance           ao = b * | ----------- |                                       //
+  // bptIn = bptAmountIn             \    bpt    /                                        //
+  // bpt = bptTotalSupply                                                                 //
+  *****************************************************************************************/
+
+  // Token out, so we round down overall
+  // This means rounding down on both multiplication and division
+
+  const bptRatio = fp.divDown(bptAmountIn, bptTotalSupply);
+
+  const amountsOut = new Array<BigNumber>(balances.length);
+  for (let i = 0; i < balances.length; i++) {
+    amountsOut[i] = fp.mulDown(balances[i], bptRatio);
+  }
+
+  return amountsOut;
+};
+
+export const _calcDueTokenProtocolSwapFeeAmount = (
+  balance: BigNumber,
+  normalizedWeight: BigNumber,
+  previousInvariant: BigNumber,
+  currentInvariant: BigNumber,
+  protocolSwapFeePercentage: BigNumber
+): BigNumber => {
+  /*********************************************************************************
+  /*  protocolSwapFeePercentage * balanceToken * ( 1 - (previousInvariant / currentInvariant) ^ (1 / weightToken))
+  *********************************************************************************/
+
+  if (currentInvariant.lte(previousInvariant)) {
+    // This shouldn't happen outside of rounding errors, but have this safeguard nonetheless to prevent the Pool
+    // from entering a locked state in which joins and exits revert while computing accumulated swap fees.
+    return fp.ZERO;
+  }
+
+  // We round down to prevent issues in the Pool's accounting, even if it means paying slightly less in protocol
+  // fees to the Vault.
+
+  // Fee percentage and balance multiplications round down, while the subtrahend (power) rounds up (as does the
+  // base). Because previousInvariant / currentInvariant <= 1, the exponent rounds down.
+
+  let base = fp.divUp(previousInvariant, currentInvariant);
+  const exponent = fp.divDown(fp.ONE, normalizedWeight);
+
+  // Because the exponent is larger than one, the base of the power function has a lower bound. We cap to this
+  // value to avoid numeric issues, which means in the extreme case (where the invariant growth is larger than
+  // 1 / min exponent) the Pool will pay less in protocol fees than it should.
+  base = base.gte(fp.MIN_POW_BASE_FREE_EXPONENT)
+    ? base
+    : fp.MIN_POW_BASE_FREE_EXPONENT;
+
+  const power = fp.powUp(base, exponent);
+
+  const tokenAccruedFees = fp.mulDown(balance, fp.complement(power));
+  return fp.mulDown(tokenAccruedFees, protocolSwapFeePercentage);
+};
+
+// Convenience method needed by the SOR package (adapted from _calcBptOutGivenExactTokensIn)
+export const _calcBptOutGivenExactTokenIn = (
+  balance: BigNumber,
+  normalizedWeight: BigNumber,
+  amountIn: BigNumber,
+  bptTotalSupply: BigNumber,
+  swapFee: BigNumber
+): BigNumber => {
+  // BPT out, so we round down overall
+
+  const tokenBalanceRatioWithoutFee = fp.divDown(
+    fp.add(balance, amountIn),
+    balance
+  );
+  const weightedBalanceRatio = fp.mulDown(
+    tokenBalanceRatioWithoutFee,
+    normalizedWeight
+  );
+
+  let invariantRatio = fp.ONE;
+
+  // Percentage of the amount supplied that will be swapped for other tokens in the pool
+  let tokenBalancePercentageExcess: BigNumber;
+  // Some tokens might have amounts supplied in excess of a 'balanced' join: these are identified if
+  // the token's balance ratio sans fee is larger than the weighted balance ratio, and swap fees charged
+  // on the amount to swap
+  if (weightedBalanceRatio.gte(tokenBalanceRatioWithoutFee)) {
+    tokenBalancePercentageExcess = fp.ZERO;
+  } else {
+    tokenBalancePercentageExcess = fp.divUp(
+      fp.sub(tokenBalanceRatioWithoutFee, weightedBalanceRatio),
+      fp.sub(tokenBalanceRatioWithoutFee, fp.ONE)
+    );
+  }
+
+  const swapFeeExcess = fp.mulUp(swapFee, tokenBalancePercentageExcess);
+  const amountInAfterFee = fp.mulDown(amountIn, fp.complement(swapFeeExcess));
+
+  const tokenBalanceRatio = fp.add(
+    fp.ONE,
+    fp.divDown(amountInAfterFee, balance)
+  );
+
+  invariantRatio = fp.mulDown(
+    invariantRatio,
+    fp.powDown(tokenBalanceRatio, normalizedWeight)
+  );
+
+  return fp.mulDown(bptTotalSupply, fp.sub(invariantRatio, fp.ONE));
+};
+
+// Convenience method needed by the SOR package (adapted from _calcBptInGivenExactTokensOut)
+export function _calcBptInGivenExactTokenOut(
+  balance: BigNumber,
+  normalizedWeight: BigNumber,
+  amountOut: BigNumber,
+  bptTotalSupply: BigNumber,
+  swapFee: BigNumber
+): BigNumber {
+  // BPT in, so we round up overall
+
+  const tokenBalanceRatioWithoutFee = fp.divUp(
+    fp.sub(balance, amountOut),
+    balance
+  );
+  const weightedBalanceRatio = fp.mulUp(
+    tokenBalanceRatioWithoutFee,
+    normalizedWeight
+  );
+
+  let invariantRatio = fp.ONE;
+
+  // Percentage of the amount supplied that will be swapped for other tokens in the pool
+  let tokenBalancePercentageExcess: BigNumber;
+  // For each ratioSansFee, compare with the total weighted ratio (weightedBalanceRatio) and
+  // decrease the fee from what goes above it
+  if (weightedBalanceRatio.lte(tokenBalanceRatioWithoutFee)) {
+    tokenBalancePercentageExcess = fp.ZERO;
+  } else {
+    tokenBalancePercentageExcess = fp.divUp(
+      fp.sub(weightedBalanceRatio, tokenBalanceRatioWithoutFee),
+      fp.complement(tokenBalanceRatioWithoutFee)
+    );
+  }
+
+  const swapFeeExcess = fp.mulUp(swapFee, tokenBalancePercentageExcess);
+  const amountOutBeforeFee = fp.divUp(amountOut, fp.complement(swapFeeExcess));
+
+  const tokenBalanceRatio = fp.complement(
+    fp.divUp(amountOutBeforeFee, balance)
+  );
+
+  invariantRatio = fp.mulDown(
+    invariantRatio,
+    fp.powDown(tokenBalanceRatio, normalizedWeight)
+  );
+
+  return fp.mulUp(bptTotalSupply, fp.complement(invariantRatio));
+}

--- a/src/make.ts
+++ b/src/make.ts
@@ -150,7 +150,7 @@ export const makeAmountOutGivenReservesFunction = (
         amountIn,
         sortedReserves[0],
         sortedReserves[1],
-        true,
+        stable,
         extraSettings?.customA,
         extraSettings?.customFees,
         extraSettings?.customDecimals?.[0], // Balancer only looks at amt in
@@ -243,7 +243,8 @@ export const makeSingleSidedWithdrawalGivenReserves = (
         extraSettings?.customA,
         extraSettings?.customFees,
         extraSettings?.customRates,
-        totalSupply
+        totalSupply,
+        stable
       );
     };
   }


### PR DESCRIPTION
- port `weighted-math` from https://github.com/georgeroman/balancer-v2-pools/blob/main/src/pools/weighted/
- add Balancer weighted pool support for `makeAmountOutFunction()`
- add Balancer weighted pool support for `makeSingleSidedWithdrawalFunction()` 
- add tests for above new features in `bal.test.ts`